### PR TITLE
Fixed nationalist estate not being included in the has_any_estate trigger

### DIFF
--- a/common/scripted_triggers/00_scripted_triggers_estates.txt
+++ b/common/scripted_triggers/00_scripted_triggers_estates.txt
@@ -30,5 +30,6 @@ has_any_estates = {
 		has_estate = estate_vampires
 		has_estate = estate_raj_ministries
 		has_estate = estate_castonath_patricians
+		has_estate = estate_nationalist
 	}
 }


### PR DESCRIPTION
The nationalist estate was not included in the trigger, resulting in one not being able to seize land when you only had the nationalist estate. Unfortunately, this also fixes the crown land faction balancer not working when you just have the nationalist estate, but what can you do... Well, the estate is OP enough as it is, so a small price to pay. 

p.s. Sorry if this isn't proper etiquette when fixing these sorts of things... Wasn't sure if I should've done it via a pull request, or just should've submitted a issue for it. 